### PR TITLE
Generalized monitor changes

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -218,7 +218,7 @@ class Monitor():
                 f" , creation_time=NOW() ")
         log.info(query)
         result = self.db.query('koa', query)
-        if result is False: 
+        if result is False:
             handle_error('QUEUE_INSERT_ERROR', f'{__name__} failed: {query}')
             return
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -361,7 +361,7 @@ class KtlMonitor():
 
             # monitor keys for services that don't have a lastfile equivalent
             for key in filepath_keys:
-                keyword = ktl.cache(service, key)
+                keyword = ktl.cache(keys['service'], key)
                 keyword.monitor()
 
             #monitor keyword that indicates new file
@@ -445,7 +445,7 @@ def handle_error(errcode, text=None, check_time=True):
     '''Email admins the error but only if we haven't sent one recently.'''
 
     #always log/print
-    if log: self.log.error(f'{errcode}: {text}')
+    if log: log.error(f'{errcode}: {text}')
     else: print(text)
 
     #Only send if we haven't sent one of same errcode recently


### PR DESCRIPTION
I have modified the monitor part to be able to handle instruments with a lastfile type keyword as well as instruments where the lastfile must be constructed from other keywords.

Notable changes: 
the configuration has five parts: 1) The service being monitored, 2) the keyword we're watching to determine when a new file is available, 3) the value we're looking for, if necessary, to determine if it's the right state to look for the new file, 4) the list of keywords needed to get the full filepath to the new file, for instruments with a keyword for this it is just the list with that keyword, otherwise it is a list of keywords to be used in the next part, 5) a lambda function that takes a diction of values mapped to the keywords that returns the formatted string of the full filepath.

Parts 4 and 5 allow us to configure each instrument and, more importantly, each service differently to handle edge cases while leaving the execution as a general function.