### PR TITLE
Auto-correct DATEOBS and UTC if values are duplicating causing duplicate KOAID errors

### DIFF
--- a/src/dep.py
+++ b/src/dep.py
@@ -928,13 +928,12 @@ class DEP:
             utstring = dt.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
             if not self.update_dep_status('ipac_notify_time', utstring): return False
             apiData = self.get_api_data(apiUrl)
-# Need to remove this line when API is fixed
-            if isinstance(apiData, str): apiData = json.loads(apiData)
             if not apiData or not apiData.get('APIStatus') or apiData.get('APIStatus') != 'COMPLETE':
                 self.log_error('IPAC_API_ERROR', apiUrl)
                 self.update_dep_status('status', 'ERROR')
                 self.update_dep_status('status_code', 'IPAC_NOTIFY_ERROR')
                 return False
+            log.info("IPAC API response: ", apiData)
             return True
         # Transfer error
         else:

--- a/src/dep.py
+++ b/src/dep.py
@@ -359,8 +359,10 @@ class DEP:
 
         #form filepath and copy
         if invalid: 
-            if self.dirs: outfile = f"{self.dirs['udf']}/{self.utdatedir}/{self.ofname}"
-            else:         outfile = f"{self.rootdir}/{self.instr}/stage/udf/{self.ofname}"
+            #NOTE: We decided to not make udf copies of invalid files.
+            pass
+            # if self.dirs: outfile = f"{self.dirs['udf']}/{self.utdatedir}/{self.ofname}"
+            # else:         outfile = f"{self.rootdir}/{self.instr}/stage/udf/{self.ofname}"
         else:       
             outfile = f"{self.dirs['stage']}/{self.utdatedir}/{self.ofname}"
         if outfile == self.filepath:

--- a/src/dep.py
+++ b/src/dep.py
@@ -200,8 +200,11 @@ class DEP:
 
         #If entry exists and we are not reprocessing, return error
         if len(rows) > 0 and not self.reprocess:
-            self.log_invalid('DUPLICATE_KOAID')
-            return False
+            if self.check_fix_datetime():
+                self.log_warn('DATETIME_FIX')
+            else:
+                self.log_invalid('DUPLICATE_KOAID')
+                return False
 
         #if reprocessing, delete local files by KOAID
         if self.reprocess:
@@ -360,7 +363,7 @@ class DEP:
         #form filepath and copy
         if invalid: 
             #NOTE: We decided to not make udf copies of invalid files.
-            pass
+            return True
             # if self.dirs: outfile = f"{self.dirs['udf']}/{self.utdatedir}/{self.ofname}"
             # else:         outfile = f"{self.rootdir}/{self.instr}/stage/udf/{self.ofname}"
         else:       
@@ -970,6 +973,40 @@ class DEP:
             return False
 
         return True
+
+
+    def check_fix_datetime(self):
+        '''
+        See if filemod time differs from DATEOBS+UTC.  
+        If so, correct DATEOBS and UTC and reset KOAID.
+
+        TODO: NOTE: This may not work b/c the UTC keyword looks to be the time the 
+        data started being taken, not the last file mod time which is all that
+        we can get from unix/os.stat.  To correctly compare the two we would 
+        need to account for exposure+readout, otherwise this will often see
+        them as being different.  And vice-versa, to set UTC from modtime is not
+        really accurate without accounting for exp/readout.  But, we do that in 
+        set_utc() anyway, so maybe it doesn't matter.
+        '''
+        try:
+            mtime_utc = os.stat(self.filepath).st_mtime + (10*60*60)
+            dateobs = self.get_keyword('DATE-OBS')
+            utc = self.get_keyword('UTC')
+            tm = dt.datetime.strptime(f'{dateobs} {utc}', '%Y-%m-%d %H:%M:%S.%f').timestamp()
+            diffsec = abs(tm - mtime_utc)
+            log.info('Difference betwen file modtime and DATEOBS+UTC is {diffsec} seconds')                
+            if diffsec < 60: 
+                return False
+
+            #fix it
+            self.set_utc_from_modtime()
+            self.set_dateobs_from_modtime()
+            self.set_koaid(force=True)
+            return True
+
+        except Exception as e:
+            self.log_warn("CHECK_FIX_DATETIME_ERROR", str(e))
+            return False
 
 
     def log_warn(self, errcode, text=''):

--- a/src/instrument.py
+++ b/src/instrument.py
@@ -612,7 +612,6 @@ class Instrument(dep.DEP):
         utc = self.get_keyword('UTC')
         is_daytime = self.is_daytime(utc)
 
-        print ('is_zero_propint: ', koaimtyp, is_daytime, has_target)
         return (is_cal and is_daytime and not has_target)
 
 


### PR DESCRIPTION
My solution may not work well b/c we cannot simply compare file modtime to DATEOBS/UTC time.  The UTC keyword looks to be the time the data started being taken, not the last file mod time which is all that we can get from unix/os.stat.  To correctly compare the two we would need to account for exposure+readout, otherwise this will often see them as being different.  And vice-versa, to set UTC from modtime is not really accurate without accounting for exp/readout.  But, we do that in set_utc() anyway, so maybe it doesn't matter.  I put an arbitrary 60 second threshold to indicate the file modtime does not match up with the DATEOBS/UTC time.  Need to review this solution before we merge it.