### PR TITLE
Added check if duplicate koaid then see if dateobs/utc need to be cor…

### DIFF
--- a/src/instrument.py
+++ b/src/instrument.py
@@ -139,13 +139,14 @@ class Instrument(dep.DEP):
         (self.fits_hdu[ext].header).update({keyword : (value, comment)})
 
 
-    def set_koaid(self):
+    def set_koaid(self, force=False):
         '''
         Create and add KOAID to header if it does not already exist
         '''
 
         #skip if it exists
-        if self.get_keyword('KOAID', False) != None: return True
+        if not force and self.get_keyword('KOAID', False) != None: 
+            return True
 
         #make it
         koaid = self.make_koaid()
@@ -320,13 +321,8 @@ class Instrument(dep.DEP):
                 valid = True
 
         #if we couldn't match valid pattern, then build from file last mod time
-        #note: converting to universal time (+10 hours)
         if not valid:
-            lastMod = os.stat(self.filepath).st_mtime
-            dateObs = dt.datetime.fromtimestamp(lastMod) + dt.timedelta(hours=10)
-            dateObs = dateObs.strftime('%Y-%m-%d')
-            self.set_keyword('DATE-OBS', dateObs, 'KOA: Observing date')
-            log.warning('set_dateObs: set DATE-OBS value from FITS file time')
+            self.set_dateobs_from_modtime()
 
         # If good match, just take first 10 chars (some dates have 'T' format and extra time)
         if len(dateObs) > 10:
@@ -337,6 +333,15 @@ class Instrument(dep.DEP):
 
         return True
        
+
+    def set_dateobs_from_modtime(self):
+
+        #note: converting to universal time (+10 hours)
+        lastMod = os.stat(self.filepath).st_mtime
+        dateObs = dt.datetime.fromtimestamp(lastMod) + dt.timedelta(hours=10)
+        dateObs = dateObs.strftime('%Y-%m-%d')
+        self.set_keyword('DATE-OBS', dateObs, 'KOA: Observing date')
+        log.warning('set_dateObs: set DATE-OBS value from FITS file time')
 
 
     def set_utc(self):
@@ -362,16 +367,20 @@ class Instrument(dep.DEP):
         #if we couldn't match valid pattern, then build from file last mod time
         #note: converting to universal time (+10 hours)
         if not valid:
-            lastMod = os.stat(self.filepath).st_mtime
-            utc = dt.datetime.fromtimestamp(lastMod) + dt.timedelta(hours=10)
-            utc = utc.strftime('%H:%M:%S.00')
-            update = True
-            log.warning('set_utc: set UTC value from FITS file time')
-        #update/add if need be
-        if update:
+            self.set_utc_from_modtime()
+        elif update:
             self.set_keyword('UTC', utc, 'KOA: UTC keyword corrected')
         return True
 
+        
+    def set_utc_from_modtime(self):
+
+        #note: converting to universal time (+10 hours)
+        lastMod = os.stat(self.filepath).st_mtime
+        utc = dt.datetime.fromtimestamp(lastMod) + dt.timedelta(hours=10)
+        utc = utc.strftime('%H:%M:%S.00')
+        log.warning('set_utc: set UTC value from FITS file time')
+        self.set_keyword('UTC', utc, 'KOA: UTC keyword corrected')
 
 
     def set_ut(self):


### PR DESCRIPTION
…rected based on filemod time.

I pushed a solution to branch jriley-dkoa-100, but this may not work well b/c we cannot simply compare file modtime to DATEOBS/UTC time.  The UTC keyword looks to be the time the data started being taken, not the last file mod time which is all that we can get from unix/os.stat.  To correctly compare the two we would need to account for exposure+readout, otherwise this will often see them as being different.  And vice-versa, to set UTC from modtime is not really accurate without accounting for exp/readout.  But, we do that in set_utc() anyway, so maybe it doesn't matter.  I put an arbitrary 60 second threshold to indicate the file modtime does not match up with the DATEOBS/UTC time.  Need to review this solution before we merge it.