### PR TITLE
envlog hostname and monitor controller updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ dmypy.json
 /src/test/koadata_test
 *.bak
 /src/test/tmp/
+
+*.orig
+notes.txt
+.gitignore

--- a/doc/tables.sql
+++ b/doc/tables.sql
@@ -95,6 +95,15 @@ CREATE TABLE IF NOT EXISTS `koa_summary` (
   `last_mod`      datetime      DEFAULT CURRENT_TIMESTAMP  COMMENT 'Time of last modification'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ;
 
+CREATE TABLE IF NOT EXISTS `koa_storage` (
+  `id`                    int(11)       NOT NULL  AUTO_INCREMENT PRIMARY KEY,
+  `instrument`            varchar(15)   DEFAULT NULL        COMMENT 'Instrument name',
+  `utdate`                date          DEFAULT NULL        COMMENT 'UT date of summary',
+  `storage_type`          varchar(15)   DEFAULT NULL        COMMENT 'Storage type [AWS, SharePoint, stage]',
+  `storage_location`      varchar(100)  DEFAULT NULL        COMMENT 'Storage location',
+  `last_mod`              datetime      DEFAULT CURRENT_TIMESTAMP  COMMENT 'Time of last modification'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ;
+
 CREATE TABLE IF NOT EXISTS `odap_queue` (
   `filename`       varchar(250) NOT NULL COMMENT 'File to send to ODAP',
   `koaid`          varchar(48)           COMMENT 'Unique KOA ID',

--- a/src/config.ini
+++ b/src/config.ini
@@ -18,6 +18,7 @@ DATABASE: {
 }
 
 API: {
+  MAIN:      'https://server/api',
   TELAPI:    'telSchedule.php?',
   PROPAPI:   'proposalsAPI.php?',
   METAPI:    'metrics.php?'

--- a/src/dep.py
+++ b/src/dep.py
@@ -1168,6 +1168,7 @@ class DEP:
         '''
         Gets data for common calls to url API requests.
         '''
+        log.info(f'Getting data from {url}')
         try:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
@@ -1179,6 +1180,8 @@ class DEP:
                 data = data[0]
             return data
         except Exception as e:
+            log.warn(f'API call failed: {url}')
+            log.warn(str(e))
             return None
 
 

--- a/src/dep.py
+++ b/src/dep.py
@@ -1070,8 +1070,8 @@ class DEP:
 
     def get_prog_inst(self, semid, default=None, isToO=False):
         '''Query for the program institution'''
-        api = self.config.get('API', {}).get('PROPAPI')
-        url = api + 'ktn='+semid+'&cmd=getAllocInst&json=True'
+        api = self.config.get('API', {}).get('MAIN')
+        url = api + '/proposals/getAllocInst?ktn='+semid
         data = self.get_api_data(url)
         if not data or not data.get('success'):
             self.log_warn('PROP_API_ERROR', url)
@@ -1084,8 +1084,8 @@ class DEP:
     def get_prog_pi(self, semid, default=None):
         '''Query for program's PI last name'''
 
-        api = self.config.get('API', {}).get('PROPAPI')
-        url = api + 'ktn='+semid+'&cmd=getPI&json=True'
+        api = self.config.get('API', {}).get('MAIN')
+        url = api + '/proposals/getPI?ktn='+semid
         data = self.get_api_data(url)
         if not data or not data.get('success'):
             self.log_warn('PROP_API_ERROR', url)
@@ -1098,8 +1098,8 @@ class DEP:
 
     def get_prog_title(self, semid, default=None):
         '''Query the DB and get the program title'''
-        api = self.config.get('API', {}).get('PROPAPI')
-        url = api + 'ktn='+semid+'&cmd=getTitle&json=True'
+        api = self.config.get('API', {}).get('MAIN')
+        url = api + '/proposals/getTitle?ktn='+semid
         data = self.get_api_data(url)
         if not data or not data.get('success'):
             self.log_warn('PROP_API_ERROR', url)

--- a/src/envlog.py
+++ b/src/envlog.py
@@ -13,7 +13,7 @@ def envlog(telnr, dateObs, utc):
     '''
 
     #define archiver api url
-    hostname = f'k{telnr}dataserver'
+    hostname = f'k{telnr}epicsgateway'
     port = 17668
     url = f'http://{hostname}:{port}/retrieval/data/getData.json?'
 

--- a/src/instr_guider.py
+++ b/src/instr_guider.py
@@ -4,17 +4,7 @@ This is the class to handle all the GUIDER specific attributes
 
 import instrument
 import datetime as dt
-import numpy as np
-from astropy.io import fits
 import os
-import re
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-import math
-from skimage import exposure
-import traceback
-import glob
-from pathlib import Path
 import shutil
 
 import logging
@@ -140,41 +130,14 @@ class Guider(instrument.Instrument):
         Combines the results into a single list of dictionaries.
         '''
         api = self.config['API']['MAIN']
-        too = self.get_api_data(f'{api}/schedule/getToORequest&date={self.hstdate}')
         sched = []
-        for entry in too:
-            if entry['Instrument'] != instr or \
-               entry['StartTimeActual'] == None or \
-               entry['DurationActual'] == None:
-                continue
-            proj = {}
-            proj['Type'] = 'ToO'
-            proj['Date'] = entry['ObsDate']
-            for key in ['TelNr','Instrument','ProjCode']:
-                proj[key] = entry[key]
-            proj['StartTime'],proj['EndTime'] = \
-                self.convert_to_start_end(self.utdate, entry['StartTimeActual'], entry['DurationActual'])
-            sched.append(proj)
 
-        url = api.replace('telSchedule','twilightApi')
-        twilight = self.get_api_data(f'{url}cmd=twilight_select&utdate={self.utdate}')
-        for entry in twilight:
-            if instr not in entry['Instr']:
-                continue
-            proj = {}
-            proj['Type'] = 'Twilight'
-            proj['Date'] = self.hstdate
-            for key in ['TelNr','Instr','ProjCode']:
-                proj[key] = entry[key]
-            proj['StartTime'],proj['EndTime'] = \
-                self.convert_to_start_end(self.utdate, entry['StartTime'], entry['Duration'])
-            sched.append(proj)
-
+        # The new getSchedule will return ToO, twilight, and classical programs
         classical = self.get_api_data(f'{api}/schedule/getSchedule&date={self.hstdate}&instr={instr.replace("+", "%2b")}')
         for entry in classical:
             proj = {}
             proj['Type'] = 'Classical'
-            for key in ['Date','TelNr','Instrument','ProjCode','StartTime','EndTime']:
+            for key in ['Date','TelNr','Instrument','ProjCode','StartTime','EndTime','ObsType']:
                 proj[key] = entry[key]
             sched.append(proj)
 
@@ -215,7 +178,7 @@ class Guider(instrument.Instrument):
                 if ut >= start and ut <= end:
                     log.warning(f"Assigning PROGID by schedule UTC: {entry['ProjCode']}")
                     return entry['ProjCode']
-                if entry['Type'] == 'Classical':
+                if entry['ObsType'] == 'Classical':
                     if num == 0 and ut < start:
                         log.warning(f"Assigning PROGID by first scheduled entry: {entry['ProjCode']}")
                         return entry['ProjCode']

--- a/src/instr_guider.py
+++ b/src/instr_guider.py
@@ -133,7 +133,7 @@ class Guider(instrument.Instrument):
         sched = []
 
         # The new getSchedule will return ToO, twilight, and classical programs
-        classical = self.get_api_data(f'{api}/schedule/getSchedule&date={self.hstdate}&instr={instr.replace("+", "%2b")}')
+        classical = self.get_api_data(f'{api}/schedule/getSchedule?date={self.hstdate}&instr={instr.replace("+", "%2b")}')
         for entry in classical:
             proj = {}
             proj['Type'] = 'Classical'

--- a/src/instr_guider.py
+++ b/src/instr_guider.py
@@ -139,8 +139,8 @@ class Guider(instrument.Instrument):
         Queries the schedule API to return ToO, twilight, and classical programs.
         Combines the results into a single list of dictionaries.
         '''
-        api = self.config['API']['TELAPI']
-        too = self.get_api_data(f'{api}cmd=getToORequest&date={self.hstdate}')
+        api = self.config['API']['MAIN']
+        too = self.get_api_data(f'{api}/schedule/getToORequest&date={self.hstdate}')
         sched = []
         for entry in too:
             if entry['Instrument'] != instr or \
@@ -170,7 +170,7 @@ class Guider(instrument.Instrument):
                 self.convert_to_start_end(self.utdate, entry['StartTime'], entry['Duration'])
             sched.append(proj)
 
-        classical = self.get_api_data(f'{api}cmd=getSchedule&date={self.hstdate}&instr={instr.replace("+", "%2b")}')
+        classical = self.get_api_data(f'{api}/schedule/getSchedule&date={self.hstdate}&instr={instr.replace("+", "%2b")}')
         for entry in classical:
             proj = {}
             proj['Type'] = 'Classical'

--- a/src/instrument.py
+++ b/src/instrument.py
@@ -656,13 +656,13 @@ class Instrument(dep.DEP):
 
     def is_daytime(self, utc):
         """Is the UTC time during the day?"""
-        url = f"{self.config['API']['METAPI']}date={self.utdate}"
-        suntimes = self.get_api_data(url, getOne=True)
+        url = f"{self.config['API']['MAIN']}/schedule/getTwilightData?date={self.utdate}"
+        suntimes = self.get_api_data(url)
         sunrise = suntimes['sunrise']
         sunset  = suntimes['sunset']
         tm         = dt.datetime.strptime(utc,     '%H:%M:%S.%f').time()
-        sunset_tm  = dt.datetime.strptime(sunset,  '%H:%M').time()
-        sunrise_tm = dt.datetime.strptime(sunrise, '%H:%M').time()
+        sunset_tm  = dt.datetime.strptime(sunset,  '%H:%M:%S').time()
+        sunrise_tm = dt.datetime.strptime(sunrise, '%H:%M:%S').time()
         is_daytime = (tm < sunset_tm or tm > sunrise_tm)
         return is_daytime
 

--- a/src/instrument.py
+++ b/src/instrument.py
@@ -483,8 +483,8 @@ class Instrument(dep.DEP):
             splitNight = splitMap.index(splitLoc[0])
 
         #get schedule information
-        api = self.config['API']['TELAPI']
-        url = f"{api}cmd=getSchedule&date={self.hstdate}&telnr={self.telnr}&instr={self.instr}"
+        api = self.config['API']['MAIN']
+        url = f"{api}/schedule/getSchedule?date={self.hstdate}&telnr={self.telnr}&instr={self.instr}"
         log.info(f'checking schedule for PROGID: {url}')
         data = self.get_api_data(url)
         if data:
@@ -607,8 +607,8 @@ class Instrument(dep.DEP):
             propint = 18
         else:
             semid = self.get_semid()
-            api = self.config.get('API', {}).get('PROPAPI')
-            url = api + 'ktn='+semid+'&cmd=getApprovedPP&json=True'
+            api = self.config.get('API', {}).get('MAIN')
+            url = api + '/proposals/getApprovedPP?ktn='+semid
             data = self.get_api_data(url)
             if not data or not data.get('success') or data.get('data') == None:
                 if not progid.startswith('E'):
@@ -730,7 +730,7 @@ class Instrument(dep.DEP):
     def get_oa(self, hstdate, telnr):
         """Gets OA value from API for given date and telnr."""
 
-        url = f"{self.config['API']['TELAPI']}cmd=getNightStaff&date={hstdate}&telnr={telnr}"
+        url = f"{self.config['API']['MAIN']}/employee/getNightStaff?date={hstdate}&telnr={telnr}"
         log.info(f'retrieving night staff info: {url}')
         data = self.get_api_data(url)
         oa = 'None'
@@ -810,7 +810,7 @@ class Instrument(dep.DEP):
         """
         Gets telescope number for instrument via API
         """
-        url = f"{self.config['API']['TELAPI']}cmd=getTelnr&instr={self.instr.upper()}"
+        url = f"{self.config['API']['MAIN']}/schedule/getTelnr?instr={self.instr.upper()}"
         data = self.get_api_data(url, getOne=True)
         self.telnr = int(data['TelNr'])
         if self.telnr not in [1, 2]:

--- a/src/koa_osiris_lev1.py
+++ b/src/koa_osiris_lev1.py
@@ -349,8 +349,8 @@ def main():
 
     # Is OSIRIS scheduled for the night?  Get account being used.
     try:
-        url  = config['API']['TELAPI']
-        url = f'{url}cmd=getSchedule&date={tonight}&instr={instrument}'
+        url  = config['API']['MAIN']
+        url = f'{url}/schedule/getSchedule?date={tonight}&instr={instrument}'
         resp = requests.get(url)
         response = json.loads(resp.text)
         if len(response) == 0:

--- a/src/monctl
+++ b/src/monctl
@@ -46,41 +46,64 @@
 
 wait_secs=10   # ops
 
+
 ## ===== K1 Instrument Lists ===== ##
 # INSTRUMENT LISTS - to be fixed in later version
 # for now, supply custom run list where indicated for long term use
 
 # K1 L0/raw instrument lists
-k1InstList=( "guiderk1" "hires" "kpf" "lris_blue" "lris_red" "mosfire" "osiris_img" "osiris_spec" )   # required for count
+k1InstList=( "guiderk1" "hires" "kpf" "lris_blue" "lris_red" "mosfire" "osiris_img" "osiris_spec" )   # NO EDIT required for total count
 k1_base_list=${k1InstList[@]}
 k1_base_count=${#k1InstList[@]}
-#k1InstList=( " " " ")   # customized instrument list(s)
+
+# ///// K1 customized instrument list(s) here: \\\\\
+#k1InstList=( "guiderk1" "hires" "lris_blue" "lris_red" "mosfire" "osiris_img" "osiris_spec" )   # no KPF
+#k1InstList=( "kpf" )                                                                            # KPF only
+# \\\\\ K1 customized instrument list(s) end: /////
+
 k1_run_list=${k1InstList[@]}
 k1_run_count=${#k1InstList[@]}
 
 # K1 DRP instrument lists
-k1InstDrpList=( "kpf" "mosfire" "osiris" )   # required for count
+k1InstDrpList=( "kpf" "mosfire" "osiris" )   #  NO EDIT required for total count
 k1_base_drp_list=${k1InstDrpList[@]}
 k1_base_drp_count=${#k1InstDrpList[@]}
-#k1InstDrpList=( " " " ")   # customized drp instrument list(s)
+
+# ///// K1 DRP customized instrument list(s) here: \\\\\
+k1InstDrpList=( "mosfire" "osiris" )                       # no KPF DRP
+k1InstDrpList=( "kpf" )                                    # KPF DRP only
+# \\\\\ K1 DRP customized instrument list(s) end: /////
+
 k1_run_drp_list=${k1InstDrpList[@]}
 k1_run_drp_count=${#k1InstDrpList[@]}
+
 
 ## ===== K2 Instrument Lists ===== ##
 
 # K2 L0/raw instrument lists
-k2InstList=( "deimos_fcs" "deimos_spec" "esi" "guiderk2" "kcwi_blue" "kcwi_fcs" "kcwi_red" "nirc2_unp" "nirc2" "nires_img" "nires_spec" "nirspec_scam" "nirspec_spec" )   # required for count
+k2InstList=( "deimos_fcs" "deimos_spec" "esi" "guiderk2" "kcwi_blue" "kcwi_fcs" "kcwi_red" "nirc2_unp" "nirc2" "nires_img" "nires_spec" "nirspec_scam" "nirspec_spec" )   #  NO EDIT required for count
 k2_base_list=${k2InstList[@]}
 k2_base_count=${#k2InstList[@]}
-#k2InstList=( " " " ")   # customized instrument list(s)
+
+# ///// K2 customized instrument list(s) here: \\\\\
+#k2InstList=( "deimos_fcs" "deimos_spec" "guiderk2" "kcwi_blue" "kcwi_fcs" "kcwi_red" "nirc2_unp" "nirc2" "nires_img" "nires_spec" "nirspec_scam" "nirspec_spec" )   # no ESI
+#k2InstList=( "esi" )   # ESI only
+# \\\\\ K2 customized instrument list(s) end: /////
+
 k2_run_list=${k2InstList[@]}
 k2_run_count=${#k2InstList[@]}
 
 # K2 DRP instrument lists
-k2InstDrpList=( "kcwi" "deimos" "esi" "nirc2" "nires" )    # required for count
+k2InstDrpList=( "kcwi" "deimos" "esi" "nirc2" "nires" )   #  NO EDIT required for total count
 k2_base_drp_list=${k2InstDrpList[@]}
 k2_base_drp_count=${#k2InstDrpList[@]}
 #k2InstDrpList=( " " " ")   # customized drp instrument list(s)
+
+# ///// K2 DRP customized instrument list(s) here: \\\\\
+#k2InstDrpList=( "kcwi" "deimos" "nirc2" "nires" )        # no ESI drp
+#k2InstDrpList=( "esi" )                                  # ESI DRP only
+# \\\\\ K2 DRP customized instrument list(s) end: /////
+
 k2_run_drp_list=${k2InstDrpList[@]}
 k2_run_drp_count=${#k2InstDrpList[@]}
 

--- a/src/monctl
+++ b/src/monctl
@@ -5,13 +5,6 @@
 
 # Restore: server names, instrument lists, wait_time
 
-# *** CAUTION ***
-#     instrument run lists contain all instruments
-#     add instrument list(s) as desired
-#     (see monctl_dev branch for custom instrument lists)
-# *** CAUTION ***
-
-# Execute on an RTI ops or test server as the rti user
 #   SVRK1 (k1 instruments), SVRK2 (k2 instruments), or SVRBLD (k0, k1 and k2 instruments combined)
 #   servers are auto-detected by the script by hostname
 

--- a/src/monctl
+++ b/src/monctl
@@ -70,8 +70,8 @@ k1_base_drp_list=${k1InstDrpList[@]}
 k1_base_drp_count=${#k1InstDrpList[@]}
 
 # ///// K1 DRP customized instrument list(s) here: \\\\\
-k1InstDrpList=( "mosfire" "osiris" )                       # no KPF DRP
-k1InstDrpList=( "kpf" )                                    # KPF DRP only
+#k1InstDrpList=( "mosfire" "osiris" )                       # no KPF DRP
+#k1InstDrpList=( "kpf" )                                    # KPF DRP only
 # \\\\\ K1 DRP customized instrument list(s) end: /////
 
 k1_run_drp_list=${k1InstDrpList[@]}

--- a/src/monctl
+++ b/src/monctl
@@ -5,6 +5,7 @@
 
 # Restore: server names, instrument lists, wait_time
 
+#Execute on an RTI ops or test server as the rti user
 #   SVRK1 (k1 instruments), SVRK2 (k2 instruments), or SVRBLD (k0, k1 and k2 instruments combined)
 #   servers are auto-detected by the script by hostname
 


### PR DESCRIPTION
**envlog.py:**
changed hostname from k]1|2]dataserver to k[1|2]epicsgateway

monctl
provided proper instructions for adding instrument lists for raw and drp data on both RTI servers
