### PR TITLE
allow a pass when no mask is found in the database

### DIFF
--- a/src/instr_lris.py
+++ b/src/instr_lris.py
@@ -1188,6 +1188,10 @@ class Lris(instrument.Instrument):
         api_url = f'{api_base}?gui-name={guiname}'
         resp = requests.get(api_url)
 
+        if resp.status_code == 422:
+            log.warning(f"No mask exists in db for {guiname}")
+            return False
+
         try:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
An update to log a warning instead of creating a ADD_SLITMASK_ERROR status_code,  when a mask is not found in the slitmask db from the guiname in the header.   This was the original intent and was lost in commit 

Commit 81ff737

on Dec 25, 2025
Update get_ext_data_order() to skip if now VidInp